### PR TITLE
Add global editorconfig

### DIFF
--- a/roles/dotfiles/tasks/main.yml
+++ b/roles/dotfiles/tasks/main.yml
@@ -44,3 +44,8 @@
   copy:
     src: sqliterc
     dest: ~/.sqliterc
+
+- name: deploy global editorconfig
+  template:
+    src: editorconfig.j2
+    dest: ~/.editorconfig

--- a/roles/dotfiles/templates/editorconfig.j2
+++ b/roles/dotfiles/templates/editorconfig.j2
@@ -1,0 +1,14 @@
+{{ ansible_managed | comment }}
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
Add a global file in the $HOME to apply editorconfig to all projects without specific config.