### PR TITLE
Fix gem cleanup hanging on "yes"

### DIFF
--- a/roles/cleanup/tasks/main.yml
+++ b/roles/cleanup/tasks/main.yml
@@ -5,6 +5,6 @@
   changed_when: "clean_homebrew_result.stdout != ''"
 
 - name: cleanup gem
-  command: yes | gem cleanup
+  command: gem cleanup
   changed_when: false
   ignore_errors: true


### PR DESCRIPTION
I don't know what was the purpose of the `yes |` part of the command, but it was the cause of the problem.

Fix #48. 