### PR TITLE
Use custom symfony plugin

### DIFF
--- a/roles/dotfiles/tasks/main.yml
+++ b/roles/dotfiles/tasks/main.yml
@@ -5,16 +5,22 @@
     dest: ~/.oh-my-zsh
     force: yes
 
-- name: Clone syntax-highlighting
+- name: Clone syntax-highlighting plugin
   git:
     repo: https://github.com/zsh-users/zsh-syntax-highlighting.git
     dest: ~/.oh-my-zsh/custom/plugins/zsh-syntax-highlighting
     force: yes
 
-- name: Clone zsh-autosuggestions
+- name: Clone zsh-autosuggestions plugin
   git:
     repo: https://github.com/zsh-users/zsh-autosuggestions
     dest: ~/.oh-my-zsh/custom/plugins/zsh-autosuggestions
+    force: yes
+
+- name: Clone symfony plugin
+  git:
+    repo: git@github.com:TheGrowingPlant/symfony.plugin.zsh.git
+    dest: ~/.oh-my-zsh/custom/plugins/symfony
     force: yes
 
 - name: deploy .zshrc

--- a/roles/dotfiles/templates/zshrc.j2
+++ b/roles/dotfiles/templates/zshrc.j2
@@ -7,7 +7,7 @@ ZSH_THEME="{{ zsh_theme|mandatory }}"
 DISABLE_UPDATE_PROMPT=true
 {% if zsh_autosuggestions|bool %}ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE='fg=030'{% endif %}
 
-plugins=(git history-substring-search sudo symfony2 composer brew httpie extract {% if zsh_syntax_highlighting|bool %}zsh-syntax-highlighting{% endif %} {% if zsh_autosuggestions|bool %}zsh-autosuggestions{% endif %})
+plugins=(git history-substring-search sudo composer symfony brew httpie extract {% if zsh_syntax_highlighting|bool %}zsh-syntax-highlighting{% endif %} {% if zsh_autosuggestions|bool %}zsh-autosuggestions{% endif %})
 source $ZSH/oh-my-zsh.sh
 
 DEFAULT_USER="{{ lookup('env','USER') }}"


### PR DESCRIPTION
Fix #51

I create a basic plugin for OhMyZsh and Symfony, see https://github.com/TheGrowingPlant/symfony.plugin.zsh

I remove all unused aliases and remove support of app/console (sf 2).

The plugin also works with syntax-highlighting.