### PR TITLE
Rewrite manage_services role to fix issue with sudo

### DIFF
--- a/default.config.yml
+++ b/default.config.yml
@@ -21,17 +21,20 @@ homebrew_packages: []
 mas_upgrade_all_apps: no
 mas_installed_apps: []
 
-managed_services:
-  - { name: nginx, sudo: true }
-  - { name: "php@{{ php_version }}" }
-  - { name: redis }
-  - { name: dnsmasq }
-  - { name: mailhog }
-  - { name: mariadb }
-  - { name: "postgresql@{{ postgresql_version }}" }
+managed_services_as_user:
+  - "php@{{ php_version }}"
+  - redis
+  - dnsmasq
+  - mailhog
+  - mariadb
+  - "postgresql@{{ postgresql_version }}"
+  - blackfire-agent
+
+managed_services_as_root:
+  - nginx
 
 managed_plists:
-  - { name: com.minio.minio }
+  - com.minio.minio
 
 ############
 # dotfiles #

--- a/roles/manage_services/tasks/main.yml
+++ b/roles/manage_services/tasks/main.yml
@@ -1,17 +1,32 @@
 ---
-- command: "brew services {{ service_state }} {{ item.name }}"
-  with_items: "{{ managed_services }}"
-  become: "{{ item.sudo|default(false) }}"
-  ignore_errors: true
 
-- command: "launchctl unload /Users/{{ lookup('env','USER') }}/Library/LaunchAgents/{{ item.name }}.plist"
+- name: get currently started brew services
+  shell: "brew services list | grep -E 'started|error' | awk '{ print $1 }'"
+  register: started_brew_services
+  changed_when: false
+
+- name: manage brew services as user
+  command: "brew services {{ service_state }} {{ item }}"
+  with_items: "{{ managed_services_as_user }}"
+  when: (service_state == 'stop' and item in started_brew_services.stdout_lines) or service_state != 'stop'
+
+- name: manage brew services as root
+  command: "brew services {{ service_state }} {{ item }}"
+  with_items: "{{ managed_services_as_root }}"
+  when: (service_state == 'stop' and item in started_brew_services.stdout_lines) or service_state != 'stop'
+  become: yes
+
+- name: get currently loaded plists
+  shell: "launchctl list  | awk '{ print $3 }'"
+  register: loaded_plists
+  changed_when: false
+
+- name: launchctl unload
+  command: "launchctl unload /Users/{{ lookup('env','USER') }}/Library/LaunchAgents/{{ item }}.plist"
   with_items: "{{ managed_plists }}"
-  when: service_state == 'stop' or service_state == 'restart'
-  become: "{{ item.sudo|default(false) }}"
-  ignore_errors: true
+  when: (service_state == 'stop' or service_state == 'restart') and item in loaded_plists.stdout_lines
 
-- command: "launchctl load /Users/{{ lookup('env','USER') }}/Library/LaunchAgents/{{ item.name }}.plist"
+- name: launchctl load
+  command: "launchctl load /Users/{{ lookup('env','USER') }}/Library/LaunchAgents/{{ item }}.plist"
   with_items: "{{ managed_plists }}"
   when: service_state == 'start' or service_state == 'restart'
-  become: "{{ item.sudo|default(false) }}"
-  ignore_errors: true

--- a/roles/minio/templates/minio.plist.j2
+++ b/roles/minio/templates/minio.plist.j2
@@ -12,7 +12,7 @@
     <key>KeepAlive</key>
     <true/>
     <key>Label</key>
-    <string>homebrew.mxcl.minio</string>
+    <string>{{ minio_plist_name }}</string>
     <key>ProgramArguments</key>
     <array>
       <string>/usr/local/opt/minio/bin/minio</string>


### PR DESCRIPTION
Fix #68 

The issue with sudo come from the last releases of Ansible (> 2.7) where `  become: "{{ item.sudo|default(false) }}"` no longer works.
To fix that I split the task in 2: root services and user services.

I clean up the error handling for start/stop state.