### PR TITLE
Set nginx vhost in /etc/hosts

### DIFF
--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -58,3 +58,19 @@
   loop_control:
     label: "{{ item.name }}"
   notify: Restart nginx
+
+- name: Remove old entries in /etc/hosts
+  lineinfile:
+    dest: /etc/hosts
+    regexp: "# Ansible managed"
+    state: absent
+  become: true
+
+- name: Updating the /etc/hosts
+  lineinfile:
+    dest: /etc/hosts
+    line: "127.0.0.1 {{ item.server_name }} # Ansible managed"
+  with_items: "{{ nginx_sites }}"
+  loop_control:
+    label: "{{ item.server_name }}"
+  become: true


### PR DESCRIPTION
Bypass https://discourse.brew.sh/t/brews-curl-openssl-cant-resolve-localhost-hostnames-set-up-in-dnsmasq-system-curl-has-no-issue/5327/5