### PR TITLE
Generate only one certificate for nginx instead of one per site

### DIFF
--- a/default.config.yml
+++ b/default.config.yml
@@ -208,6 +208,10 @@ nginx_sites:
     redirect_to_https: true
     https: true
 
+nginx_certificates:
+  - localhost
+  - 127.0.0.1
+
 #########
 # DNS   #
 #########

--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -16,8 +16,14 @@
     state: directory
   with_items:
     - "{{ nginx_confs_path }}"
-    - "{{ nginx_certificates_path }}"
     - "{{ nginx_vhosts_path }}"
+
+- name: Clean old directory
+  file:
+    path: '{{ item }}'
+    state: absent
+  with_items:
+    - "{{ nginx_path }}/certificates"
 
 - name: Add confs
   template:
@@ -52,11 +58,8 @@
     dest: '{{ nginx_vhosts_path }}/dev'
   notify: Restart nginx
 
-- name: Create certs
-  shell: "mkcert -cert-file {{ nginx_certificates_path }}/{{ item.name }}.crt -key-file {{ nginx_certificates_path }}/{{ item.name }}.key {{ item.server_name }}"
-  with_items: "{{ nginx_sites }}"
-  loop_control:
-    label: "{{ item.name }}"
+- name: Create certificate
+  shell: mkcert -cert-file {{ nginx_ssl_certificate }} -key-file {{ nginx_ssl_certificate_key }} "{{ (nginx_certificates + (nginx_sites | map(attribute='server_name') | list)) | join('" "') }}"
   notify: Restart nginx
 
 - name: Remove old entries in /etc/hosts

--- a/roles/nginx/templates/sites/default.j2
+++ b/roles/nginx/templates/sites/default.j2
@@ -2,8 +2,12 @@
 
 server {
     listen {{ nginx_http_port }};
+    listen {{ nginx_https_port }} ssl http2;
     server_name  localhost;
     root       {{ playbook_dev_path | realpath }}/local-homepage;
+
+    ssl_certificate      {{ nginx_ssl_certificate }};
+    ssl_certificate_key  {{ nginx_ssl_certificate_key }};
 
     error_log {{ nginx_log_path }}/default.error.log;
     access_log {{ nginx_log_path }}/default.access.log;

--- a/roles/nginx/templates/sites/site.j2
+++ b/roles/nginx/templates/sites/site.j2
@@ -8,8 +8,8 @@ server {
     {% if site.root is defined %}root {{ site.root | expanduser }};{% endif %}
 
     {% if site.https|default(true) %}
-    ssl_certificate      {{ nginx_certificates_path }}/{{ site.name }}.crt;
-    ssl_certificate_key  {{ nginx_certificates_path }}/{{ site.name }}.key;
+    ssl_certificate      {{ nginx_ssl_certificate }};
+    ssl_certificate_key  {{ nginx_ssl_certificate_key }};
     {% endif %}
 
     access_log {{ nginx_log_path }}/{{ site.name }}.access.log main;

--- a/roles/nginx/vars/main.yml
+++ b/roles/nginx/vars/main.yml
@@ -6,13 +6,16 @@
 nginx_http_port: 80
 nginx_https_port: 443
 nginx_http2: true
+
 nginx_default_site_root: "/usr/local/var/www"
 nginx_path: /usr/local/etc/nginx
 nginx_conf_file_path: "{{ nginx_path }}/nginx.conf"
 nginx_confs_path: "{{ nginx_path }}/conf.d"
-nginx_certificates_path: "{{ nginx_path }}/certificates"
 nginx_vhosts_path: "{{ nginx_path }}/sites-enabled"
 nginx_log_path: /usr/local/var/log/nginx
+
+nginx_ssl_certificate: "{{ nginx_path }}/certificate.crt"
+nginx_ssl_certificate_key: "{{ nginx_path }}/certificate.key"
 
 nginx_site_types:
   - symfony


### PR DESCRIPTION
Instead of generate one certificate per site, we generate only one certificate for all sites.