### PR TITLE
Stay on ruby 2

### DIFF
--- a/roles/common/vars/main.yml
+++ b/roles/common/vars/main.yml
@@ -26,6 +26,6 @@ homebrew_base_packages:
   - mas
   - wget
   - bat
-  - ruby
+  - ruby@2.7
   - vips # https://github.com/lovell/sharp/issues/1593#issuecomment-475680243
   - gnu-tar

--- a/roles/dotfiles/templates/zshrc.j2
+++ b/roles/dotfiles/templates/zshrc.j2
@@ -34,7 +34,7 @@ export PATH=~/.composer/vendor/bin:./vendor/bin:$PATH
 [ -e "${HOME}/.load_node" ] && source "${HOME}/.load_node"
 
 # RUBY
-export PATH="/usr/local/opt/ruby/bin:$PATH"
+export PATH="/usr/local/opt/ruby@2.7/bin:$PATH"
 
 # Python
 export PATH="/usr/local/opt/python@3/libexec/bin:$PATH"


### PR DESCRIPTION
`ruby` is now linked to ruby 3