### PR TITLE
:fire: Remove services tap

### DIFF
--- a/roles/common/vars/main.yml
+++ b/roles/common/vars/main.yml
@@ -1,6 +1,5 @@
 ---
 homebrew_tap:
-  - homebrew/services
   - buo/cask-upgrade
 
 homebrew_base_packages:


### PR DESCRIPTION
The tap is now deprecated, see:

>  homebrew/services was deprecated. This tap is now empty and all its contents were either deleted or migrated